### PR TITLE
add location_bbox

### DIFF
--- a/geoserver_data_dir/layouts/style-editor-legend.xml
+++ b/geoserver_data_dir/layouts/style-editor-legend.xml
@@ -1,0 +1,3 @@
+<layout>
+    <decoration type="legend" affinity="top,right" offset="0,0" size="auto"/>
+</layout>

--- a/geoserver_data_dir/workspaces/vector/location_bbox/datastore.xml
+++ b/geoserver_data_dir/workspaces/vector/location_bbox/datastore.xml
@@ -1,0 +1,20 @@
+<dataStore>
+  <id>DataStoreInfoImpl--7d32349b:17564db7347:-7ffc</id>
+  <name>location_bbox</name>
+  <description>location bounding box</description>
+  <type>GeoPackage</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl-53a0964:16fc2624139:-7fff</id>
+  </workspace>
+  <connectionParameters>
+    <entry key="Batch insert size">1</entry>
+    <entry key="database">file:data/location_bbox.gpkg</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key="Expose primary keys">false</entry>
+    <entry key="dbtype">geopkg</entry>
+    <entry key="namespace">vector</entry>
+  </connectionParameters>
+  <__default>false</__default>
+  <dateCreated>2020-10-26 12:24:48.997 UTC</dateCreated>
+</dataStore>

--- a/geoserver_data_dir/workspaces/vector/location_bbox/location_bbox/featuretype.xml
+++ b/geoserver_data_dir/workspaces/vector/location_bbox/location_bbox/featuretype.xml
@@ -1,0 +1,50 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--7d32349b:17564db7347:-7ffb</id>
+  <name>location_bbox</name>
+  <nativeName>location_bbox</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-53a0964:16fc2624139:-7ffe</id>
+  </namespace>
+  <title>location_bbox</title>
+  <keywords>
+    <string>features</string>
+    <string>location_bbox</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--7d32349b:17564db7347:-7ffc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/geoserver_data_dir/workspaces/vector/location_bbox/location_bbox/layer.xml
+++ b/geoserver_data_dir/workspaces/vector/location_bbox/location_bbox/layer.xml
@@ -1,0 +1,17 @@
+<layer>
+  <name>location_bbox</name>
+  <id>LayerInfoImpl--7d32349b:17564db7347:-7ffa</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--30af9c43:17564f1c471:-7ffc</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--7d32349b:17564db7347:-7ffb</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+  <dateCreated>2020-10-26 12:27:52.159 UTC</dateCreated>
+  <dateModified>2020-10-26 12:56:54.890 UTC</dateModified>
+</layer>

--- a/geoserver_data_dir/workspaces/vector/styles/location_bbox.css
+++ b/geoserver_data_dir/workspaces/vector/styles/location_bbox.css
@@ -1,0 +1,8 @@
+/* @title Selection */
+* {
+  stroke: #ff00ff;
+  stroke-width: 4;
+  stroke-opacity: 0.5;
+  fill: #bbbbbb;
+  fill-opacity: 0.2;
+}

--- a/geoserver_data_dir/workspaces/vector/styles/location_bbox.sld
+++ b/geoserver_data_dir/workspaces/vector/styles/location_bbox.sld
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+  <sld:NamedLayer>
+    <sld:Name>Default Styler</sld:Name>
+    <sld:UserStyle>
+      <sld:Name>Default Styler</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:Title>Selection</sld:Title>
+          <sld:PolygonSymbolizer>
+            <sld:Fill>
+              <sld:CssParameter name="fill">#bbbbbb</sld:CssParameter>
+              <sld:CssParameter name="fill-opacity">0.2</sld:CssParameter>
+            </sld:Fill>
+            <sld:Stroke>
+              <sld:CssParameter name="stroke">#ff00ff</sld:CssParameter>
+              <sld:CssParameter name="stroke-opacity">0.5</sld:CssParameter>
+              <sld:CssParameter name="stroke-width">4</sld:CssParameter>
+            </sld:Stroke>
+          </sld:PolygonSymbolizer>
+        </sld:Rule>
+        <sld:VendorOption name="ruleEvaluation">first</sld:VendorOption>
+      </sld:FeatureTypeStyle>
+    </sld:UserStyle>
+  </sld:NamedLayer>
+</sld:StyledLayerDescriptor>
+

--- a/geoserver_data_dir/workspaces/vector/styles/location_bbox.xml
+++ b/geoserver_data_dir/workspaces/vector/styles/location_bbox.xml
@@ -1,0 +1,14 @@
+<style>
+  <id>StyleInfoImpl--30af9c43:17564f1c471:-7ffc</id>
+  <name>location_bbox</name>
+  <workspace>
+    <id>WorkspaceInfoImpl-53a0964:16fc2624139:-7fff</id>
+  </workspace>
+  <format>css</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>location_bbox.css</filename>
+  <dateCreated>2020-10-26 12:55:23.966 UTC</dateCreated>
+  <dateModified>2020-10-26 12:57:13.898 UTC</dateModified>
+</style>

--- a/webapp/scripts/add_location.js
+++ b/webapp/scripts/add_location.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const { addOsm, checkWritableDir, getCoordinates, gpkgOut, mapsetExists } = require('./functions')
+const { addOsm, checkWritableDir, getCoordinates, gpkgOut, mapsetExists, grass } = require('./functions')
 const { add_location: messages } = require('./messages.json')
 
 const GEOSERVER = `${process.env.GEOSERVER_DATA_DIR}/data`
@@ -47,6 +47,10 @@ class AddLocationModule {
         gpkgOut('PERMANENT', 'points_osm', 'points')
         gpkgOut('PERMANENT', 'lines_osm', 'lines')
         gpkgOut('PERMANENT', 'polygons_osm', 'polygons')
+        // use buildings/municipality boundaries to set the location bbox
+        grass('PERMANENT', `g.region vector=polygons_osm`)
+        grass('PERMANENT', 'v.in.region output=location_bbox')
+        gpkgOut('PERMANENT', 'location_bbox', 'location_bbox')
 
         let [east, north] = getCoordinates('PERMANENT')
 

--- a/webapp/views/map/script.js
+++ b/webapp/views/map/script.js
@@ -34,6 +34,14 @@ const buildings = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
   minZoom: 1
 });
 
+const location_bbox = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
+  layers: 'vector:location_bbox',
+  format: 'image/png',
+  transparent: true,
+  maxZoom: 20,
+  minZoom: 1
+});
+
 const selection = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
   layers: 'vector:selection',
   format: 'image/png',
@@ -129,9 +137,10 @@ const groupedOverlays = {
     'OpenStreetMap': osm
   },
   "Basemap": {
+    'Basemap boundary': location_bbox,
     'Water lines': waterLines,
     'Roads': roads,
-    'Buildings': buildings,
+    'Buildings': buildings
   },
   "User inputs": {
     'Current selection': selection,

--- a/webapp/views/map/script.js
+++ b/webapp/views/map/script.js
@@ -34,7 +34,7 @@ const buildings = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
   minZoom: 1
 });
 
-const location_bbox = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
+const locationBbox = L.tileLayer.wms(geoserverUrl + 'geoserver/vector/wms', {
   layers: 'vector:location_bbox',
   format: 'image/png',
   transparent: true,
@@ -137,7 +137,7 @@ const groupedOverlays = {
     'OpenStreetMap': osm
   },
   "Basemap": {
-    'Basemap boundary': location_bbox,
+    'Basemap boundary': locationBbox,
     'Water lines': waterLines,
     'Roads': roads,
     'Buildings': buildings


### PR DESCRIPTION
Instead of using the whole basemap, I currently use the multi-polygon layer - which are the buildings/municipal boundaries - to generate the bounding box. Because some road lines extend very long out of the city, which will cause the bounding box to be unnecessarily large - and it makes no sense at the moment for the user to set the selection to somewhere without any urban infrastructure or human activity.