### PR TITLE
Query

### DIFF
--- a/grass/variables/defaults/query.ps_param
+++ b/grass/variables/defaults/query.ps_param
@@ -12,8 +12,21 @@ mapinfo
 
 vareas query_result
   color red
-  width 1
-  masked n
+  fcolor yellow
+  width 0.2
+  end
+
+vpoints query_result
+  color red
+  fcolor yellow
+  symbol basic/triangle
+  size 5
+  end
+
+vlines query_result
+  color red
+  width 0.2
+  masked y
   end
 
 vlines lines

--- a/webapp/scripts/grass.js
+++ b/webapp/scripts/grass.js
@@ -243,7 +243,7 @@ function listVector(mapset) {
  * @return {string[]} names of available maps
  */
 function listUserVector() {
-  return grass('PERMANENT', 'g.list type=vector mapset=*').trim().split('\n').filter(filterDefaultLayers)
+  return grass('PERMANENT', 'g.list -m type=vector').trim().split('\n').filter(filterDefaultLayers)
 }
 
 /**

--- a/webapp/scripts/modules/query.js
+++ b/webapp/scripts/modules/query.js
@@ -70,7 +70,7 @@ module.exports = class {
     return {
       id: 'query.2',
       message: translations['query.message.2'],
-      list: listUserVector()
+      list: listUserVector().map(file => file.split('@')[0])
     }
   }
 


### PR DESCRIPTION
Query module should only query maps from the 'PERMANENT' mapset, because:
1. layers from the layer switcher are added in the 'PERMANENT' mapset
2. add_map function adds map into the 'PERMANENT' mapset
3. other mapset folders have dedicated use, and the maps inside are usually not queriable
4. much easier to manage on the code side, since most GRASS commands require a 'mapset' input.